### PR TITLE
Fixed fmt required version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ class Boundless2DRecipe(ConanFile):
 
     def requirements(self):
         self.requires("spdlog/1.12.0")
-        self.requires("fmt/10.0.0")
+        self.requires("fmt/10.1.1")
 
     def configure(self):
         if self.settings.os == "Windows":


### PR DESCRIPTION
While building bl2d for the first time, conan complained about fmt and spdlog required versions conflicting and didn't the generate projects and solution files.
![image](https://github.com/Ohjurot/Boundless2D/assets/57322933/ae83f5ef-d1e1-475c-8333-cc3f655cfb22)

So this PR basically only updates the required minimum version for fmt and now generates the project files as it should.